### PR TITLE
fix(auth): add support for setting auth header and cookie manually

### DIFF
--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -58,6 +58,18 @@ def parse_args() -> argparse.Namespace:
         help=("The maximum number of retries to make on failed attempts to fetch an activity. "
               "Exponential backoff will be used, meaning that the delay between successive attempts "
               "will double with every retry, starting at one second. DEFAULT: {}").format(DEFAULT_MAX_RETRIES))
+    parser.add_argument(
+        "--token",
+        default=None,
+        type=str,
+        help=("Authentication header token. Use with 'jwt_fgp' instead of username and password, for example "
+              "if login fails due to ReCaptcha."))
+    parser.add_argument(
+        "--jwt_fgp",
+        default=None,
+        type=str,
+        help=("Authentication JWT_FGP Cookie. Use with 'token' instead of username and password, for example "
+              "if login fails due to ReCaptcha."))
 
     return parser.parse_args()
 
@@ -69,6 +81,8 @@ def main():
     try:
         incremental_backup(username=args.username,
                            password=args.password,
+                           token=args.token,
+                           jwt_fgp=args.jwt_fgp,
                            backup_dir=args.backup_dir,
                            export_formats=args.format,
                            ignore_errors=args.ignore_errors,

--- a/garminexport/cli/get_activity.py
+++ b/garminexport/cli/get_activity.py
@@ -43,6 +43,18 @@ def main():
         "--log-level", metavar="LEVEL", type=str,
         help="Desired log output level (DEBUG, INFO, WARNING, ERROR). Default: INFO.",
         default="INFO")
+    parser.add_argument(
+        "--token",
+        default=None,
+        type=str,
+        help=("Authentication header token. Use with 'jwt_fgp' instead of username and password, for example "
+              "if login fails due to ReCaptcha."))
+    parser.add_argument(
+        "--jwt_fgp",
+        default=None,
+        type=str,
+        help=("Authentication JWT_FGP Cookie. Use with 'token' instead of username and password, for example "
+              "if login fails due to ReCaptcha."))
 
     args = parser.parse_args()
 
@@ -60,10 +72,11 @@ def main():
         if not os.path.isdir(args.destination):
             os.makedirs(args.destination)
 
-        if not args.password:
+        prompt_password = not args.password and (not args.token or not args.jwt_fgp)
+        if prompt_password:
             args.password = getpass.getpass("Enter password: ")
 
-        with GarminClient(args.username, args.password) as client:
+        with GarminClient(args.username, args.password, args.token, args.jwt_fgp) as client:
             log.info("fetching activity %s ...", args.activity)
             summary = client.get_activity_summary(args.activity)
             # set up a retryer that will handle retries of failed activity downloads


### PR DESCRIPTION
> An approach for mitigating issue #113. This PR allows the user to set the `Authorization` header and `JWT_FGP` cookie through command line args, e.g.,
> 
> ```shell
> export TOKEN="longer_token_here"
> export JWT_FGP="shorter-cookie-here"
> garmin-backup --token=$TOKEN --jwt_fgp=$JWT_FGP username
> ```
> 
> Where the token/cookie can be found under the Network>Headers/Cookies tab in your browser's DevTools in requests to `connect.garmin.com`.


https://github.com/petergardfjall/garminexport/pull/115