### PR TITLE
feat: adding bulk get activity and update activity methods 

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -275,20 +275,35 @@ class GarminClient(object):
         :rtype: tuples of (int, datetime)
         """
         ids = []
+        for activity in self._fetch_activities():
+            id = int(activity["activityId"])
+            timestamp_utc = dateutil.parser.parse(activity["startTimeGMT"])
+            # make sure UTC timezone gets set
+            timestamp_utc = timestamp_utc.replace(tzinfo=dateutil.tz.tzutc())
+            ids.append((id, timestamp_utc))
+        return ids
+
+    @require_session
+    def get_activities(self):
+        """Return all activities with all their information.
+
+        :return: The full list of activities, with all their information.
+        :rtype: list of activities info dicts.
+        """
+        activities = []
         batch_size = 100
         # fetch in batches since the API doesn't allow more than a certain
         # number of activities to be retrieved on every invocation
         for start_index in range(0, sys.maxsize, batch_size):
-            next_batch = self._fetch_activity_ids_and_ts(start_index, batch_size)
-            if not next_batch:
+            activity_batch = self._fetch_activities(start_index, batch_size)
+            if not activity_batch:
                 break
-            ids.extend(next_batch)
-        return ids
+            activities.extend(activity_batch)
+        return activities
 
     @require_session
-    def _fetch_activity_ids_and_ts(self, start_index, max_limit=100):
-        """Return a sequence of activity ids (along with their starting
-        timestamps) starting at a given index, with index 0 being the user's
+    def _fetch_activities(self, start_index, max_limit=100):
+        """Return a sequence of activities information starting at a given index, with index 0 being the user's
         most recently registered activity.
 
         Should the index be out of bounds or the account empty, an empty list is returned.
@@ -298,41 +313,24 @@ class GarminClient(object):
         :param max_limit: The (maximum) number of activities to retrieve.
         :type max_limit: int
 
-        :returns: A list of activity JSON dicts describing the activity
-        :rtype: tuples of (int, datetime)
+        :return: A list of activities information.
+        :rtype: list of activity information dicts.
         """
-        log.debug(
-            "fetching activities %d through %d ...",
-            start_index,
-            start_index + max_limit - 1,
-        )
+        log.debug("fetching activities %d through %d ...", start_index, start_index + max_limit - 1)
         response = self.session.get(
             "https://connect.garmin.com/activitylist-service/activities/search/activities",
-            params={"start": start_index, "limit": max_limit},
-        )
+            params={"start": start_index, "limit": max_limit})
         if response.status_code != 200:
             raise Exception(
                 "failed to fetch activities {} to {} types: {}\n{}".format(
-                    start_index,
-                    (start_index + max_limit - 1),
-                    response.status_code,
-                    response.text,
-                )
-            )
+                    start_index, (start_index + max_limit - 1), response.status_code, response.text))
         activities = json.loads(response.text)
         if not activities:
             # index out of bounds or empty account
             return []
 
-        entries = []
-        for activity in activities:
-            id = int(activity["activityId"])
-            timestamp_utc = dateutil.parser.parse(activity["startTimeGMT"])
-            # make sure UTC timezone gets set
-            timestamp_utc = timestamp_utc.replace(tzinfo=dateutil.tz.tzutc())
-            entries.append((id, timestamp_utc))
-        log.debug("got %d activities.", len(entries))
-        return entries
+        log.debug("got %d activities.", len(activities))
+        return activities
 
     @require_session
     def get_activity_summary(self, activity_id):
@@ -705,6 +703,33 @@ class GarminClient(object):
 
         return activity_id
 
+    @require_session
+    def update_activity(self, activity_id, update_kind, update_data):
+        """Update an existing activity.
+
+        :param activity_id: Activity identifier.
+        :type activity_id: int
+        :param update_kind: Kind of data to update. Can be 'activityTypeDTO' to change the type,
+        'activityName' to change its name, ...
+        :type update_kind: str
+        :param update_data New content. For example, to change the type of an activity, should be a dict
+        like {"typeKey": "indoor_cardio"}.
+        :type update_data depends on the kind of data to update, mainly str, int or dict.
+        """
+
+        # Prepare request body
+        data = {update_kind: update_data, 'activityId': activity_id}
+
+        # Update
+        encoding_headers = {"Content-Type": "application/json; charset=UTF-8"}  # see Tapiriik
+        response = self.session.put(
+            "https://connect.garmin.com/proxy/activity-service/activity/{}".format(activity_id),
+            data=json.dumps(data), headers=encoding_headers)
+        if response.status_code != 204:
+            raise Exception(u"failed to update {} activity {}: {}\n{}".format(
+                update_kind, activity_id, response.status_code, response.text))
+        return
+
 
 def new_http_session():
     """Returns a requests-compatible HTTP Session.
@@ -729,3 +754,4 @@ def new_http_session():
     except ImportError:
         pass
     return session_factory_func()
+

--- a/samples/count_activity_by_type.py
+++ b/samples/count_activity_by_type.py
@@ -1,0 +1,27 @@
+import json
+import logging
+
+import dateutil.parser
+
+from garminexport.garminexport.garminclient import GarminClient
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+#with GarminClient('my@email.com', 'password') as client:
+#    activities = client.get_activities()
+with open('../../data/activities.json') as f:
+    activities = json.loads(f.read())
+    log.info("Loading %d activities", len(activities))
+
+    activities_by_type = {}
+    for activity in activities:
+        activity_type = activity['activityType']['typeKey']
+        if not activities_by_type.get(activity_type):
+            activities_by_type[activity_type] = []
+        activities_by_type[activity_type].append(activity)
+
+    log.info(f"Found the following activities : {activities_by_type.keys()}")
+
+    for activity_type in activities_by_type.keys():
+        log.info(f"Found {len(activities_by_type[activity_type])} {activity_type} activities.")

--- a/samples/fix_untyped_activities.py
+++ b/samples/fix_untyped_activities.py
@@ -1,0 +1,17 @@
+import logging
+
+from garminexport.garminexport.garminclient import GarminClient
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+with GarminClient('my@email.com', 'password') as client:
+    activities = client.get_activities()
+    log.info("num ids: %d", len(activities))
+
+    for activity in activities:
+        if activity['activityType']['typeKey'] == 'other':
+            activity_id = activity['activityId']
+            log.info(f"Got an untyped activity : {activity_id}")
+            client.update_activity(activity_id, 'activityTypeDTO', {"typeKey": "indoor_cardio"})
+            client.update_activity(activity_id, 'eventTypeDTO', {"typeKey": "training"})

--- a/samples/get_swim_activity.py
+++ b/samples/get_swim_activity.py
@@ -1,0 +1,41 @@
+import json
+import logging
+
+import dateutil.parser
+
+from garminexport.garminexport.garminclient import GarminClient
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+#with GarminClient('my@email.com', 'password') as client:
+#    activities = client.get_activities()
+with open('../../data/activities.json') as f:
+    activities = json.loads(f.read())
+    log.info("Loading %d activities", len(activities))
+
+    swim = []
+    for activity in activities:
+        if activity["activityType"]["typeKey"] == 'lap_swimming':
+            log.info("Found swim activity {}".format(dateutil.parser.parse(activity["startTimeGMT"]).date()))
+            swim.append(activity)
+
+    log.info(f"Found {len(swim)} swim activities")
+
+    swim_candidates = []
+    for activity in activities:
+        if activity['movingDuration'] is not None and 2400 > activity['movingDuration'] > 1000 and activity[
+            'distance'] is not None and 500 < activity['distance'] < 1500:
+            swim_candidates.append(activity)
+    log.info(f"Found {len(swim_candidates)} swim candidates")
+
+    mistyped = []
+    for activity in swim_candidates:
+        if activity['activityType']['typeKey'] != 'lap_swimming':
+            log.info("Found a mistyped swimming activity : {}".format(
+                dateutil.parser.parse(activity["startTimeGMT"]).date()))
+            mistyped.append(activity)
+
+    for activity in mistyped:
+        if activity['activityType']['typeKey'] == 'other':
+            client.update_activity(activity['activityId'], 'activityTypeDTO', {"typeKey": "lap_swimming"})

--- a/samples/load_activities.py
+++ b/samples/load_activities.py
@@ -1,0 +1,9 @@
+import json
+import logging
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+with open('../../data/activities.json') as f:
+    activities = json.loads(f.read())
+    log.info("Loading %d activities", len(activities))

--- a/samples/remove_duplicates.py
+++ b/samples/remove_duplicates.py
@@ -1,0 +1,36 @@
+import json
+import logging
+from datetime import date
+
+import dateutil.parser
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+# with GarminClient('my@email.com', 'password') as client:
+#    activities = client.get_activities()
+with open('../../data/activities.json') as f:
+    activities = json.loads(f.read())
+    log.info("Loading %d activities", len(activities))
+
+    duplicates = []
+    i: int = 0
+    while i < len(activities):
+        activity_i = activities[i]
+        activity_i_date: date = dateutil.parser.parse(activity_i["startTimeGMT"]).date()
+        activity_i_type = activity_i['activityType']['typeKey']
+        j: int = len(activities) - 1
+        while j > i:
+            activity_j = activities[j]
+            activity_j_date: date = dateutil.parser.parse(activity_j["startTimeGMT"]).date()
+            activity_j_type = activity_j['activityType']['typeKey']
+            # Evaluate by date (ignoring hours)
+            if activity_i_date == activity_j_date and (
+                    activity_i_type == 'lap_swimming' or activity_j_type == 'lap_swimming'):
+                duplicates.append([activity_i, activity_j])
+            j -= 1
+        i += 1
+
+    log.info(f"Found %d swim duplicates", len(duplicates))
+    for activity in duplicates:
+        log.info("Duplicate at {}".format(dateutil.parser.parse(activity[0]["startTimeGMT"]).date()))

--- a/samples/sample.py
+++ b/samples/sample.py
@@ -38,10 +38,7 @@ if __name__ == "__main__":
             activity = client.get_activity_summary(latest_activity)
             log.info("activity id: %s", activity["activity"]["activityId"])
             log.info("activity name: '%s'", activity["activity"]["activityName"])
-            log.info(
-                "activity description: '%s'",
-                activity["activity"]["activityDescription"],
-            )
+            log.info("activity description: '%s'", activity["activityDescription"])
             log.info(json.dumps(client.get_activity_details(latest_activity), indent=4))
             log.info(client.get_activity_gpx(latest_activity))
     except Exception as e:

--- a/samples/store_activities.py
+++ b/samples/store_activities.py
@@ -1,0 +1,13 @@
+import json
+import logging
+
+from garminexport.garminexport.garminclient import GarminClient
+
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)-15s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+with GarminClient('my@email.com', 'password') as client:
+    activities = client.get_activities()
+    log.info("Stored %d activities", len(activities))
+    with open('../../data/activities.json', "w") as f:
+        f.write(json.dumps(activities, ensure_ascii=False, indent=4))


### PR DESCRIPTION
> garminclient.py - Adding get_activities method to get all the data at once, adding update_activity to modify an activity
> sample/* - Adding base examples for getting and modifying activities
> 
> I needed to clean the activities that I imported from Tomtom sports application. I have refactored and added some methods to query, filter and update activites.
> I also provided more samples, it might help others.

https://github.com/petergardfjall/garminexport/pull/74 by @ldenisey